### PR TITLE
Migration to standard `Result` and `Optional` types

### DIFF
--- a/EssentialFeed/EssentialFeed/FeedAPI/HTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/FeedAPI/HTTPClient.swift
@@ -7,13 +7,10 @@
 
 import Foundation
 
-public enum HTTPClientResult {
-    case success(Data, HTTPURLResponse)
-    case failure(Error)
-}
-
 public protocol HTTPClient {
+    typealias Result = Swift.Result<(Data, HTTPURLResponse), Error>
+
     /// The completion handler can be invoked on any thread.
     /// Clients are responsible for dispatching to appropriate threads, if needed.
-    func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void)
+    func get(from url: URL, completion: @escaping (Result) -> Void)
 }

--- a/EssentialFeed/EssentialFeed/FeedAPI/RemoteFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedAPI/RemoteFeedLoader.swift
@@ -41,7 +41,7 @@ public final class RemoteFeedLoader: FeedLoader {
 }
 
 public extension RemoteFeedLoader {
-    typealias Result = LoadFeedResult
+    typealias Result = FeedLoader.Result
     
     enum Error: Swift.Error {
         case connectivity

--- a/EssentialFeed/EssentialFeed/FeedAPI/URLSessionHTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/FeedAPI/URLSessionHTTPClient.swift
@@ -18,13 +18,15 @@ public class URLSessionHTTPClient: HTTPClient {
     
     public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
         session.dataTask(with: url) { data, response, error in
-            if let error = error {
-                completion(.failure(error))
-            } else if let data = data, let response = response as? HTTPURLResponse {
-                completion(.success((data, response)))
-            } else {
-                completion(.failure(UnexpectedValuesRepresentation()))
-            }
+            completion(Result {
+                if let error = error {
+                    throw error
+                } else if let data = data, let response = response as? HTTPURLResponse {
+                    return (data, response)
+                } else {
+                    throw UnexpectedValuesRepresentation()
+                }
+            })
         }.resume()
     }
 }

--- a/EssentialFeed/EssentialFeed/FeedAPI/URLSessionHTTPClient.swift
+++ b/EssentialFeed/EssentialFeed/FeedAPI/URLSessionHTTPClient.swift
@@ -16,12 +16,12 @@ public class URLSessionHTTPClient: HTTPClient {
         self.session = session
     }
     
-    public func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+    public func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
         session.dataTask(with: url) { data, response, error in
             if let error = error {
                 completion(.failure(error))
             } else if let data = data, let response = response as? HTTPURLResponse {
-                completion(.success(data, response))
+                completion(.success((data, response)))
             } else {
                 completion(.failure(UnexpectedValuesRepresentation()))
             }

--- a/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
@@ -10,10 +10,10 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-    typealias DeletionResult = Error?
+    typealias DeletionResult = Result<Void, Error>
     typealias DeletionCompletion = (DeletionResult) -> Void
     
-    typealias InsertionResult = Error?
+    typealias InsertionResult = Result<Void, Error>
     typealias InsertionCompletion = (InsertionResult) -> Void
     
     typealias RetrievalResult = Result<CachedFeed?, Error>

--- a/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
@@ -10,8 +10,11 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-    typealias DeletionCompletion = (Error?) -> Void
-    typealias InsertionCompletion = (Error?) -> Void
+    typealias DeletionResult = Error?
+    typealias DeletionCompletion = (DeletionResult) -> Void
+    
+    typealias InsertionResult = Error?
+    typealias InsertionCompletion = (InsertionResult) -> Void
     
     typealias RetrievalResult = Result<CachedFeed?, Error>
     typealias RetrievalCompletion = (RetrievalResult) -> Void

--- a/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
@@ -7,16 +7,17 @@
 
 import Foundation
 
-public enum RetrieveCachedFeedResult {
+public enum CachedFeed {
     case empty
     case found(feed: [LocalFeedImage], timestamp: Date)
-    case failure(Error)
 }
 
 public protocol FeedStore {
     typealias DeletionCompletion = (Error?) -> Void
     typealias InsertionCompletion = (Error?) -> Void
-    typealias RetrievalCompletion = (RetrieveCachedFeedResult) -> Void
+    
+    typealias RetrievalResult = Result<CachedFeed, Error>
+    typealias RetrievalCompletion = (RetrievalResult) -> Void
 
     /// The completion handler can be invoked on any thread.
     /// Clients are responsible for dispatching to appropriate threads, if needed.

--- a/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/FeedStore.swift
@@ -7,16 +7,13 @@
 
 import Foundation
 
-public enum CachedFeed {
-    case empty
-    case found(feed: [LocalFeedImage], timestamp: Date)
-}
+public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
     typealias DeletionCompletion = (Error?) -> Void
     typealias InsertionCompletion = (Error?) -> Void
     
-    typealias RetrievalResult = Result<CachedFeed, Error>
+    typealias RetrievalResult = Result<CachedFeed?, Error>
     typealias RetrievalCompletion = (RetrievalResult) -> Void
 
     /// The completion handler can be invoked on any thread.

--- a/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -19,41 +19,31 @@ public class CoreDataFeedStore: FeedStore {
 
     public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
         perform { context in
-            do {
+            completion(Result {
                 try ManagedCache.deleteFound(in: context)
-                completion(.success(()))
-            } catch {
-                completion(.failure(error))
-            }
+            })
         }
     }
     
     public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
         perform { context in
-            do {
+            completion(Result {
                 let managedCache = try ManagedCache.newUniqueInstance(in: context)
                 managedCache.timestamp = timestamp
                 managedCache.feed = ManagedFeedImage.images(from: feed, in: context)
                 
                 try context.save()
-                completion(.success(()))
-            } catch {
-                completion(.failure(error))
-            }
+            })
         }
     }
     
     public func retrieve(completion: @escaping RetrievalCompletion) {
         perform { context in
-            do {
-                if let cache = try ManagedCache.find(in: context) {
-                    completion(.success(CachedFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
-                } else {
-                    completion(.success(.none))
+            completion(Result {
+                try ManagedCache.find(in: context).map {
+                    return CachedFeed(feed: $0.localFeed, timestamp: $0.timestamp)
                 }
-            } catch {
-                completion(.failure(error))
-            }
+            })
         }
     }
     

--- a/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -47,9 +47,9 @@ public class CoreDataFeedStore: FeedStore {
         perform { context in
             do {
                 if let cache = try ManagedCache.find(in: context) {
-                    completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
+                    completion(.success(CachedFeed(feed: cache.localFeed, timestamp: cache.timestamp)))
                 } else {
-                    completion(.success(.empty))
+                    completion(.success(.none))
                 }
             } catch {
                 completion(.failure(error))

--- a/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -21,9 +21,9 @@ public class CoreDataFeedStore: FeedStore {
         perform { context in
             do {
                 try ManagedCache.deleteFound(in: context)
-                completion(nil)
+                completion(.success(()))
             } catch {
-                completion(error)
+                completion(.failure(error))
             }
         }
     }
@@ -36,9 +36,9 @@ public class CoreDataFeedStore: FeedStore {
                 managedCache.feed = ManagedFeedImage.images(from: feed, in: context)
                 
                 try context.save()
-                completion(nil)
+                completion(.success(()))
             } catch {
-                completion(error)
+                completion(.failure(error))
             }
         }
     }

--- a/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -47,9 +47,9 @@ public class CoreDataFeedStore: FeedStore {
         perform { context in
             do {
                 if let cache = try ManagedCache.find(in: context) {
-                    completion(.found(feed: cache.localFeed, timestamp: cache.timestamp))
+                    completion(.success(.found(feed: cache.localFeed, timestamp: cache.timestamp)))
                 } else {
-                    completion(.empty)
+                    completion(.success(.empty))
                 }
             } catch {
                 completion(.failure(error))

--- a/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/Infrastructure/CoreData/CoreDataFeedStore.swift
@@ -21,6 +21,7 @@ public class CoreDataFeedStore: FeedStore {
         perform { context in
             completion(Result {
                 try ManagedCache.deleteFound(in: context)
+                try context.save()
             })
         }
     }

--- a/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
@@ -41,7 +41,7 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader {
-    public typealias LoadResult = LoadFeedResult
+    public typealias LoadResult = FeedLoader.Result
 
     public func load(completion: @escaping (LoadResult) -> Void) {
         store.retrieve { [weak self] result in

--- a/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
@@ -48,10 +48,10 @@ extension LocalFeedLoader {
             guard let self = self else { return }
             
             switch result {
-            case let .found(feed, timestamp) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+            case let .success(.found(feed, timestamp)) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
                 completion(.success(feed.toModels()))
                 
-            case .found, .empty:
+            case .success:
                 completion(.success([]))
                 
             case .failure(let error):
@@ -70,10 +70,10 @@ extension LocalFeedLoader {
             case .failure:
                 self.store.deleteCachedFeed { _ in }
                 
-            case let .found(_, timestamp) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+            case let .success(.found(_, timestamp)) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
                 self.store.deleteCachedFeed { _ in }
 
-            case .found, .empty:
+            case .success:
                 break
             }
         }

--- a/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
@@ -48,8 +48,8 @@ extension LocalFeedLoader {
             guard let self = self else { return }
             
             switch result {
-            case let .success(.found(feed, timestamp)) where FeedCachePolicy.validate(timestamp, against: self.currentDate()):
-                completion(.success(feed.toModels()))
+            case let .success(.some(cache)) where FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
+                completion(.success(cache.feed.toModels()))
                 
             case .success:
                 completion(.success([]))
@@ -70,7 +70,7 @@ extension LocalFeedLoader {
             case .failure:
                 self.store.deleteCachedFeed { _ in }
                 
-            case let .success(.found(_, timestamp)) where !FeedCachePolicy.validate(timestamp, against: self.currentDate()):
+            case let .success(.some(cache)) where !FeedCachePolicy.validate(cache.timestamp, against: self.currentDate()):
                 self.store.deleteCachedFeed { _ in }
 
             case .success:

--- a/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedCache/LocalFeedLoader.swift
@@ -18,16 +18,18 @@ public class LocalFeedLoader: FeedLoader {
 }
 
 extension LocalFeedLoader {
-    public typealias SaveResult = Error?
+    public typealias SaveResult = Result<Void, Error>
 
     public func save(_ feed: [FeedImage], completion: @escaping (SaveResult) -> Void) {
-        store.deleteCachedFeed { [weak self] error in
+        store.deleteCachedFeed { [weak self] deletionResult in
             guard let self = self else { return }
             
-            if let cacheDeletionError = error {
-                completion(cacheDeletionError)
-            } else {
+            switch deletionResult {
+            case .success:
                 self.cache(feed, completion: completion)
+                
+            case .failure(let error):
+                completion(.failure(error))
             }
         }
     }

--- a/EssentialFeed/EssentialFeed/FeedFeature/FeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedFeature/FeedLoader.swift
@@ -7,10 +7,7 @@
 
 import Foundation
 
-public enum LoadFeedResult {
-    case success([FeedImage])
-    case failure(Error)
-}
+public typealias LoadFeedResult = Result<[FeedImage], Error>
 
 public protocol FeedLoader {
     func load(completion: @escaping ((LoadFeedResult) -> Void))

--- a/EssentialFeed/EssentialFeed/FeedFeature/FeedLoader.swift
+++ b/EssentialFeed/EssentialFeed/FeedFeature/FeedLoader.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-public typealias LoadFeedResult = Result<[FeedImage], Error>
-
 public protocol FeedLoader {
-    func load(completion: @escaping ((LoadFeedResult) -> Void))
+    typealias Result = Swift.Result<[FeedImage], Error>
+    
+    func load(completion: @escaping ((Result) -> Void))
 }

--- a/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
+++ b/EssentialFeed/EssentialFeedAPIEndToEndTests/EssentialFeedAPIEndToEndTests.swift
@@ -33,7 +33,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
     
     // MARK: - Helpers
     
-    private func getFeedResult(file: StaticString = #filePath, line: UInt = #line) -> LoadFeedResult? {
+    private func getFeedResult(file: StaticString = #filePath, line: UInt = #line) -> FeedLoader.Result? {
         let testServerURL = URL(string: "https://essentialdeveloper.com/feed-case-study/test-api/feed")!
         let client = URLSessionHTTPClient(session: URLSession(configuration: .ephemeral))
         let loader = RemoteFeedLoader(url: testServerURL, client: client)
@@ -43,7 +43,7 @@ class EssentialFeedAPIEndToEndTests: XCTestCase {
         
         let exp = XCTestExpectation(description: "Wait for load result")
         
-        var receivedResult: LoadFeedResult?
+        var receivedResult: FeedLoader.Result?
         loader.load { result in
             receivedResult = result
             exp.fulfill()

--- a/EssentialFeed/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeed/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -65,8 +65,14 @@ final class EssentialFeedCacheIntegrationTests: XCTestCase {
     
     private func save(feed: [FeedImage], with sut: LocalFeedLoader, file: StaticString = #filePath, line: UInt = #line) {
         let saveExp = expectation(description: "Wait for save completion")
-        sut.save(feed) { error in
-            XCTAssertNil(error, "Expected to save feed successfully", file: file, line: line)
+        sut.save(feed) { result in
+            switch result {
+            case .success:
+                break
+                
+            case .failure:
+                XCTFail("Expected to save feed successfully", file: file, line: line)
+            }
             saveExp.fulfill()
         }
         wait(for: [saveExp], timeout: 1.0)

--- a/EssentialFeed/EssentialFeedTests/FeedAPI/LoadFeedFromRemoteUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedAPI/LoadFeedFromRemoteUseCaseTests.swift
@@ -164,13 +164,13 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
     // MARK: - Test doubles
     
     private class HTTPClientSpy: HTTPClient {
-        private var messages: [(url: URL, completion: (HTTPClientResult) -> Void)] = []
+        private var messages: [(url: URL, completion: (HTTPClient.Result) -> Void)] = []
         
         var requestedURLs: [URL] {
             messages.map { $0.url }
         }
         
-        func get(from url: URL, completion: @escaping (HTTPClientResult) -> Void) {
+        func get(from url: URL, completion: @escaping (HTTPClient.Result) -> Void) {
             messages.append((url, completion))
         }
         
@@ -186,7 +186,7 @@ class LoadFeedFromRemoteUseCaseTests: XCTestCase {
                 headerFields: nil
             )!
             
-            messages[index].completion(.success(data, response))
+            messages[index].completion(.success((data, response)))
         }
     }
 }

--- a/EssentialFeed/EssentialFeedTests/FeedAPI/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedAPI/URLSessionHTTPClientTests.swift
@@ -127,12 +127,12 @@ class URLSessionHTTPClientTests: XCTestCase {
         }
     }
 
-    private func resultFor(data: Data?, response: URLResponse?, error: Error?, file: StaticString = #filePath, line: UInt = #line) -> HTTPClientResult {
+    private func resultFor(data: Data?, response: URLResponse?, error: Error?, file: StaticString = #filePath, line: UInt = #line) -> HTTPClient.Result {
         URLProtocolStub.stub(data: data, response: response, error: error)
               
         let sut = makeSUT(file: file, line: line)
         let expectation = XCTestExpectation(description: "Wait for completion")
-        var receivedResult: HTTPClientResult!
+        var receivedResult: HTTPClient.Result!
         
         sut.get(from: anyURL()) { result in
             receivedResult = result

--- a/EssentialFeed/EssentialFeedTests/FeedCache/CacheFeedUseCaseTests.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/CacheFeedUseCaseTests.swift
@@ -116,8 +116,14 @@ class CacheFeedUseCaseTests: XCTestCase {
     private func expect(_ sut: LocalFeedLoader, toCompleteWithError expectedError: NSError?, when action: () -> Void, file: StaticString = #filePath, line: UInt = #line) {
         let exp = XCTestExpectation(description: "Wait for save completion")
         var receivedError: Error?
-        sut.save(uniqueImageFeed().models) { error in
-            receivedError = error
+        sut.save(uniqueImageFeed().models) { result in
+            switch result {
+            case let .failure(error):
+                receivedError = error
+                
+            case .success:
+                break
+            }
             exp.fulfill()
         }
         action()

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/FailableDeleteFeedStoreSpecs.swift
@@ -22,6 +22,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
         
         deleteCache(from: sut)
 
-        expect(sut, toRetrieve: .empty, file: file, line: line)
+        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
     }
 }

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/FailableDeleteFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/FailableDeleteFeedStoreSpecs.swift
@@ -22,6 +22,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
         
         deleteCache(from: sut)
 
-        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+        expect(sut, toRetrieve: .success(.none), file: file, line: line)
     }
 }

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -24,6 +24,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
         
         insert(feed: feed, timestamp: timestamp, with: sut)
         
-        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+        expect(sut, toRetrieve: .success(.none), file: file, line: line)
     }
 }

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FailableInsertFeedStoreSpecs.swift
@@ -24,6 +24,6 @@ extension FailableInsertFeedStoreSpecs where Self: XCTestCase {
         
         insert(feed: feed, timestamp: timestamp, with: sut)
         
-        expect(sut, toRetrieve: .empty, file: file, line: line)
+        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
     }
 }

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -10,12 +10,12 @@ import XCTest
 
 extension FeedStoreSpecs where Self: XCTestCase {
     func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
-        expect(sut, toRetrieve: .empty, file: file, line: line)
+        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
     }
     
     func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         
-        expect(sut, toRetrieveTwice: .empty, file: file, line: line)
+        expect(sut, toRetrieveTwice: .success(.empty), file: file, line: line)
     }
     
     func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -25,7 +25,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         
         insert(feed: feed, timestamp: timestamp, with: sut)
 
-        expect(sut, toRetrieve: .found(feed: feed, timestamp: timestamp), file: file, line: line)
+        expect(sut, toRetrieve: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
     }
     
     func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -34,7 +34,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         
         insert(feed: feed, timestamp: timestamp, with: sut)
         
-        expect(sut, toRetrieveTwice: .found(feed: feed, timestamp: timestamp), file: file, line: line)
+        expect(sut, toRetrieveTwice: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
     }
     
     func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -59,7 +59,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         let latestTimestamp = Date()
         insert(feed: latestFeed, timestamp: latestTimestamp, with: sut)
 
-        expect(sut, toRetrieve: .found(feed: latestFeed, timestamp: latestTimestamp), file: file, line: line)
+        expect(sut, toRetrieve: .success(.found(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
     }
     
     func assertThatDeleteCacheFeedDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -71,7 +71,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     func assertThatDeleteCacheFeedHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         deleteCache(from: sut)
         
-        expect(sut, toRetrieve: .empty, file: file, line: line)
+        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
     }
     
     func assertThatDeleteCacheFeedDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -87,7 +87,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
              
         deleteCache(from: sut)
 
-        expect(sut, toRetrieve: .empty, file: file, line: line)
+        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
     }
     
     func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -147,16 +147,16 @@ extension FeedStoreSpecs where Self: XCTestCase {
         return deletionError
     }
     
-    func expect(_ sut: FeedStore, toRetrieve expectedResult: RetrieveCachedFeedResult, file: StaticString = #filePath, line: UInt = #line) {
+    func expect(_ sut: FeedStore, toRetrieve expectedResult: FeedStore.RetrievalResult, file: StaticString = #filePath, line: UInt = #line) {
         let exp = XCTestExpectation(description: "Wait for cache retrieval")
 
         sut.retrieve { retrievedResult in
             switch (expectedResult, retrievedResult) {
-            case let (.found(expectedFeed, expectedTimestamp), .found(retrievedFeed, retrievedTimestamp)):
+            case let (.success(.found(expectedFeed, expectedTimestamp)), .success(.found(retrievedFeed, retrievedTimestamp))):
                 XCTAssertEqual(expectedFeed, retrievedFeed, file: file, line: line)
                 XCTAssertEqual(expectedTimestamp, retrievedTimestamp, file: file, line: line)
                 
-            case (.empty, .empty),
+            case (.success(.empty), .success(.empty)),
                 (.failure, .failure):
                 break
                 
@@ -169,7 +169,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
     
-    func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: RetrieveCachedFeedResult, file: StaticString = #filePath, line: UInt = #line) {
+    func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: FeedStore.RetrievalResult, file: StaticString = #filePath, line: UInt = #line) {
         expect(sut, toRetrieve: expectedResult, file: file, line: line)
         expect(sut, toRetrieve: expectedResult, file: file, line: line)
     }

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -122,8 +122,15 @@ extension FeedStoreSpecs where Self: XCTestCase {
     func insert(feed: [LocalFeedImage], timestamp: Date, with sut: FeedStore) -> Error? {
         let exp = XCTestExpectation(description: "Wait for retrieve completion")
         var receivedError: Error?
-        sut.insert(feed, timestamp: timestamp) { insertionError in
-            receivedError = insertionError
+        sut.insert(feed, timestamp: timestamp) { insertionResult in
+            switch insertionResult {
+            case let .failure(error):
+                receivedError = error
+                
+            case .success:
+                break
+            }
+
             exp.fulfill()
         }
         
@@ -137,8 +144,14 @@ extension FeedStoreSpecs where Self: XCTestCase {
         let exp = XCTestExpectation(description: "Wait for delete completion")
         
         var deletionError: Error?
-        sut.deleteCachedFeed { error in
-            deletionError = error
+        sut.deleteCachedFeed { result in
+            switch result {
+            case let .failure(error):
+                deletionError = error
+                
+            case .success:
+                break
+            }
             exp.fulfill()
         }
         

--- a/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/FeedStoreSpecs/XCTestCase+FeedStoreSpecs.swift
@@ -10,12 +10,12 @@ import XCTest
 
 extension FeedStoreSpecs where Self: XCTestCase {
     func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
-        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+        expect(sut, toRetrieve: .success(.none), file: file, line: line)
     }
     
     func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         
-        expect(sut, toRetrieveTwice: .success(.empty), file: file, line: line)
+        expect(sut, toRetrieveTwice: .success(.none), file: file, line: line)
     }
     
     func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -25,7 +25,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         
         insert(feed: feed, timestamp: timestamp, with: sut)
 
-        expect(sut, toRetrieve: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
+        expect(sut, toRetrieve: .success(CachedFeed(feed: feed, timestamp: timestamp)), file: file, line: line)
     }
     
     func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -34,7 +34,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         
         insert(feed: feed, timestamp: timestamp, with: sut)
         
-        expect(sut, toRetrieveTwice: .success(.found(feed: feed, timestamp: timestamp)), file: file, line: line)
+        expect(sut, toRetrieveTwice: .success(CachedFeed(feed: feed, timestamp: timestamp)), file: file, line: line)
     }
     
     func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -59,7 +59,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
         let latestTimestamp = Date()
         insert(feed: latestFeed, timestamp: latestTimestamp, with: sut)
 
-        expect(sut, toRetrieve: .success(.found(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
+        expect(sut, toRetrieve: .success(CachedFeed(feed: latestFeed, timestamp: latestTimestamp)), file: file, line: line)
     }
     
     func assertThatDeleteCacheFeedDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -71,7 +71,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
     func assertThatDeleteCacheFeedHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
         deleteCache(from: sut)
         
-        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+        expect(sut, toRetrieve: .success(.none), file: file, line: line)
     }
     
     func assertThatDeleteCacheFeedDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -87,7 +87,7 @@ extension FeedStoreSpecs where Self: XCTestCase {
              
         deleteCache(from: sut)
 
-        expect(sut, toRetrieve: .success(.empty), file: file, line: line)
+        expect(sut, toRetrieve: .success(.none), file: file, line: line)
     }
     
     func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #filePath, line: UInt = #line) {
@@ -152,11 +152,11 @@ extension FeedStoreSpecs where Self: XCTestCase {
 
         sut.retrieve { retrievedResult in
             switch (expectedResult, retrievedResult) {
-            case let (.success(.found(expectedFeed, expectedTimestamp)), .success(.found(retrievedFeed, retrievedTimestamp))):
-                XCTAssertEqual(expectedFeed, retrievedFeed, file: file, line: line)
-                XCTAssertEqual(expectedTimestamp, retrievedTimestamp, file: file, line: line)
+            case let (.success(.some(expectedCache)), .success(.some(retrievedCache))):
+                XCTAssertEqual(expectedCache.feed, retrievedCache.feed, file: file, line: line)
+                XCTAssertEqual(expectedCache.timestamp, retrievedCache.timestamp, file: file, line: line)
                 
-            case (.success(.empty), .success(.empty)),
+            case (.success(.none), .success(.none)),
                 (.failure, .failure):
                 break
                 

--- a/EssentialFeed/EssentialFeedTests/FeedCache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/Helpers/FeedStoreSpy.swift
@@ -27,11 +27,11 @@ class FeedStoreSpy: FeedStore {
     }
     
     func completeDeletion(with error: Error, at index: Int = 0) {
-        deletionCompletions[index](error)
+        deletionCompletions[index](.failure(error))
     }
     
     func completeDeletionSuccessfully(at index: Int = 0) {
-        deletionCompletions[index](nil)
+        deletionCompletions[index](.success(()))
     }
     
     func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
@@ -40,11 +40,11 @@ class FeedStoreSpy: FeedStore {
     }
     
     func completeInsertion(with error: Error, at index: Int = 0) {
-        insertionCompletions[index](error)
+        insertionCompletions[index](.failure(error))
     }
     
     func completeInsertionSuccessfully(at index: Int = 0) {
-        insertionCompletions[index](nil)
+        insertionCompletions[index](.success(()))
     }
     
     func retrieve(completion: @escaping RetrievalCompletion) {

--- a/EssentialFeed/EssentialFeedTests/FeedCache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/Helpers/FeedStoreSpy.swift
@@ -57,10 +57,10 @@ class FeedStoreSpy: FeedStore {
     }
     
     func completeRetrievalWithNoCache(index: Int = 0) {
-        retrievalCompletions[index](.empty)
+        retrievalCompletions[index](.success(.empty))
     }
     
     func completeRetrieval(with feed: [LocalFeedImage], timestamp: Date, index: Int = 0) {
-        retrievalCompletions[index](.found(feed: feed, timestamp: timestamp))
+        retrievalCompletions[index](.success(.found(feed: feed, timestamp: timestamp)))
     }
 }

--- a/EssentialFeed/EssentialFeedTests/FeedCache/Helpers/FeedStoreSpy.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedCache/Helpers/FeedStoreSpy.swift
@@ -57,10 +57,10 @@ class FeedStoreSpy: FeedStore {
     }
     
     func completeRetrievalWithNoCache(index: Int = 0) {
-        retrievalCompletions[index](.success(.empty))
+        retrievalCompletions[index](.success(.none))
     }
     
     func completeRetrieval(with feed: [LocalFeedImage], timestamp: Date, index: Int = 0) {
-        retrievalCompletions[index](.success(.found(feed: feed, timestamp: timestamp)))
+        retrievalCompletions[index](.success(CachedFeed(feed: feed, timestamp: timestamp)))
     }
 }


### PR DESCRIPTION
Refactor the code to use the standard `Swift.Result` and `Optional` types.